### PR TITLE
Add Runware support to AI Agent configuration

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,9 @@ jobs:
           extensions: json, dom, curl, libxml, mbstring
           coverage: none
 
+      - name: Configure Composer GitHub Token
+        run: composer config -g github-oauth.github.com ${{ secrets.GH_TOKEN }}
+
       - name: Install Pint
         run: composer global require laravel/pint
 
@@ -36,6 +39,10 @@ jobs:
 
       - name: Install Rector
         run: composer require --dev driftingly/rector-laravel
+        env:
+          COMPOSER_PROCESS_TIMEOUT: 0
+          COMPOSER_NO_INTERACTION: 1
+          COMPOSER_NO_AUDIT: 1
 
       # check ./rector.php for configuration
       - name: Check Typos

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ php artisan ai-agent
 | Claude   | ✅   | ❌    | ❌    | Stable |
 | OpenAI   | ✅   | ✅    | ❌    | Stable |
 | Ideogram | ❌   | ✅    | ❌    | Stable |
+| Runware  | ❌   | ✅    | ❌    | Stable |
 
 ### Basic Usage
 

--- a/config/ai-agent.php
+++ b/config/ai-agent.php
@@ -198,6 +198,29 @@ return [
             ],
             'default_model' => env('IDEOGRAM_MODEL', 'V_2'),
         ],
+
+        'runware' => [
+            'api_key' => env('RUNWARE_API_KEY'),
+            'class' => \Kaviyarasu\AIAgent\Providers\AI\Runware\RunwareProvider::class,
+            'models' => [
+                'runware:97@1' => [
+                    'name' => 'HiDream-I1-Full',
+                    'version' => '1.0',
+                    'capabilities' => ['image'],
+                ],
+                'runware:97@2' => [
+                    'name' => 'HiDream-I1-Dev',
+                    'version' => '1.0',
+                    'capabilities' => ['image'],
+                ],
+                'runware:97@3' => [
+                    'name' => 'HiDream-I1-Fast',
+                    'version' => '1.0',
+                    'capabilities' => ['image'],
+                ],
+            ],
+            'default_model' => env('RUNWARE_MODEL', 'runware:97@2'),
+        ],
     ],
 
     /*

--- a/peck.json
+++ b/peck.json
@@ -2,7 +2,8 @@
     "preset": "laravel",
     "ignore": {
         "words": [
-            "php"
+            "php",
+            "runware"
         ],
         "paths": []
     }

--- a/src/Providers/AI/Runware/RunwareProvider.php
+++ b/src/Providers/AI/Runware/RunwareProvider.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaviyarasu\AIAgent\Providers\AI\Runware;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Kaviyarasu\AIAgent\Contracts\Capabilities\ImageGenerationInterface;
+use Kaviyarasu\AIAgent\Exceptions\AIAgentException;
+use Kaviyarasu\AIAgent\Providers\AI\AbstractProvider;
+
+class RunwareProvider extends AbstractProvider implements ImageGenerationInterface
+{
+    protected array $supportedModels = [];
+
+    protected array $modelCapabilities = [];
+
+    private const API_URL = 'https://api.runware.ai/v1';
+
+    public function __construct(array $config)
+    {
+        parent::__construct($config);
+    }
+
+    protected function loadModelsFromConfig(): void
+    {
+        $models = config('ai-agent.providers.runware.models', []);
+        $this->supportedModels = array_keys($models);
+        foreach ($models as $modelKey => $modelConfig) {
+            $this->modelCapabilities[$modelKey] = $modelConfig;
+        }
+    }
+
+    public function getName(): string
+    {
+        return 'Runware';
+    }
+
+    public function getVersion(): string
+    {
+        return '1.0';
+    }
+
+    public function supports(string $capability): bool
+    {
+        return in_array($capability, ['image']);
+    }
+
+    public function getCapabilities(): array
+    {
+        return ['image'];
+    }
+
+    public function generateImage(array $params): string
+    {
+        return $this->generateImages($params)[0] ?? '';
+    }
+
+    public function generateImages(array $params): array
+    {
+        $requestParams = [
+            'taskType' => 'imageInference',
+            'taskUUID' => (string) Str::uuid(), // Generate a UUID for each task
+            'positivePrompt' => $params['prompt'],
+            'model' => $this->currentModel,
+            'numberResults' => $params['n'] ?? 1,
+            ...$params,
+        ];
+
+        $response = Http::withHeaders([
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json'
+        ])
+            ->post(self::API_URL, [
+                [
+                    'taskType' => 'authentication',
+                    'apiKey' => $this->config['api_key'],
+                ],
+                $requestParams
+            ]);
+
+        if (! $response->successful()) {
+            logger()->error('Runware API error:', $requestParams);
+
+            throw new AIAgentException('Runware API error: '.$response->body());
+        }
+
+        $data = $response->json();
+
+        return collect($data['data'])->pluck('imageURL')->all() ?? [];
+    }
+
+    public function getSupportedFormats(): array
+    {
+        return ['PNG', 'JPG', 'WEBP'];
+    }
+
+    public function getMaxResolution(): array
+    {
+        return [
+            'width' => 2048,
+            'height' => 2048,
+        ];
+    }
+
+    public function getModelCapabilities(?string $model = null): array
+    {
+        $model = $model ?? $this->currentModel;
+
+        return $this->modelCapabilities[$model] ?? [
+            'capabilities' => ['image'],
+        ];
+    }
+
+    public function getAvailableModels(): array
+    {
+        return $this->supportedModels;
+    }
+
+    public function getDefaultModel(): string
+    {
+        return config('ai-agent.providers.runware.default_model', 'runware:97@2');
+    }
+}

--- a/src/Providers/AI/Runware/RunwareProvider.php
+++ b/src/Providers/AI/Runware/RunwareProvider.php
@@ -70,14 +70,14 @@ class RunwareProvider extends AbstractProvider implements ImageGenerationInterfa
 
         $response = Http::withHeaders([
             'Content-Type' => 'application/json',
-            'Accept' => 'application/json'
+            'Accept' => 'application/json',
         ])
             ->post(self::API_URL, [
                 [
                     'taskType' => 'authentication',
                     'apiKey' => $this->config['api_key'],
                 ],
-                $requestParams
+                $requestParams,
             ]);
 
         if (! $response->successful()) {


### PR DESCRIPTION
- Added Runware as a new provider in the config/ai-agent.php, including three models: HiDream-I1-Full, HiDream-I1-Dev, and HiDream-I1-Fast, with corresponding configuration.
- Updated README.md to list Runware under the supported providers for image tasks in the support matrix.